### PR TITLE
Satisfy .NET Native

### DIFF
--- a/Attributes/AttachableAttribute.cs
+++ b/Attributes/AttachableAttribute.cs
@@ -33,12 +33,12 @@ namespace Microsoft.Exchange.WebServices.Data
     /// The Attachable attribute decorates item classes that can be attached to other items.
     /// </summary>
     [AttributeUsage(AttributeTargets.Class, AllowMultiple = false, Inherited = false)]
-    internal sealed class AttachableAttribute : Attribute
+    public sealed class AttachableAttribute : Attribute
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="AttachableAttribute"/> class.
         /// </summary>
-        internal AttachableAttribute()
+        public AttachableAttribute()
             : base()
         {
         }

--- a/Attributes/EwsEnumAttribute.cs
+++ b/Attributes/EwsEnumAttribute.cs
@@ -33,7 +33,7 @@ namespace Microsoft.Exchange.WebServices.Data
     /// If this is used to decorate an enumeration, be sure to add that enum type to the dictionary in EwsUtilities.cs
     /// </summary>
     [AttributeUsage(AttributeTargets.Field | AttributeTargets.Property, AllowMultiple = false, Inherited = false)]
-    internal sealed class EwsEnumAttribute : Attribute
+    public sealed class EwsEnumAttribute : Attribute
     {
         /// <summary>
         /// The name for the enum value used in the server protocol
@@ -44,7 +44,7 @@ namespace Microsoft.Exchange.WebServices.Data
         /// Initializes a new instance of the <see cref="EwsEnumAttribute"/> class.
         /// </summary>
         /// <param name="schemaName">Thename used in the protocol for the enum.</param>
-        internal EwsEnumAttribute(string schemaName)
+        public EwsEnumAttribute(string schemaName)
             : base()
         {
             this.schemaName = schemaName;

--- a/Attributes/RequiredServerVersionAttribute.cs
+++ b/Attributes/RequiredServerVersionAttribute.cs
@@ -32,7 +32,7 @@ namespace Microsoft.Exchange.WebServices.Data
     /// in which they appeared.
     /// </summary>
     [AttributeUsage(AttributeTargets.Class | AttributeTargets.Field | AttributeTargets.Property, AllowMultiple = false, Inherited = false)]
-    internal sealed class RequiredServerVersionAttribute : Attribute
+    public sealed class RequiredServerVersionAttribute : Attribute
     {
         /// <summary>
         /// Exchange version.
@@ -43,7 +43,7 @@ namespace Microsoft.Exchange.WebServices.Data
         /// Initializes a new instance of the <see cref="RequiredServerVersionAttribute"/> class.
         /// </summary>
         /// <param name="version">The Exchange version.</param>
-        internal RequiredServerVersionAttribute(ExchangeVersion version)
+        public RequiredServerVersionAttribute(ExchangeVersion version)
             : base()
         {
             this.version = version;

--- a/Attributes/SchemaAttribute.cs
+++ b/Attributes/SchemaAttribute.cs
@@ -33,12 +33,12 @@ namespace Microsoft.Exchange.WebServices.Data
     /// The Schema attribute decorates classes that contain EWS schema definitions.
     /// </summary>
     [AttributeUsage(AttributeTargets.Class, AllowMultiple = false, Inherited = false)]
-    internal sealed class SchemaAttribute : Attribute
+    public sealed class SchemaAttribute : Attribute
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="SchemaAttribute"/> class.
         /// </summary>
-        internal SchemaAttribute()
+        public SchemaAttribute()
         {
         }
     }

--- a/Attributes/ServiceObjectDefinitionAttribute.cs
+++ b/Attributes/ServiceObjectDefinitionAttribute.cs
@@ -33,7 +33,7 @@ namespace Microsoft.Exchange.WebServices.Data
     /// ServiceObjectDefinition attribute decorates classes that map to EWS service objects.
     /// </summary>
     [AttributeUsage(AttributeTargets.Class, AllowMultiple = false, Inherited = false)]
-    internal sealed class ServiceObjectDefinitionAttribute : Attribute
+    public sealed class ServiceObjectDefinitionAttribute : Attribute
     {
         private string xmlElementName;
         private bool returnedByServer;
@@ -42,7 +42,7 @@ namespace Microsoft.Exchange.WebServices.Data
         /// Initializes a new instance of the <see cref="ServiceObjectDefinitionAttribute"/> class.
         /// </summary>
         /// <param name="xmlElementName">Name of the XML element.</param>
-        internal ServiceObjectDefinitionAttribute(string xmlElementName)
+        public ServiceObjectDefinitionAttribute(string xmlElementName)
             : base()
         {
             this.xmlElementName = xmlElementName;

--- a/Dns/DnsNativeMethods.cs
+++ b/Dns/DnsNativeMethods.cs
@@ -108,7 +108,7 @@ namespace Microsoft.Exchange.WebServices.Dns
         /// <param name="ptrRecords">DNS records pointer</param>
         /// <param name="freeType">Record List Free type</param>
         [SuppressMessage("Microsoft.Security", "CA2118:ReviewSuppressUnmanagedCodeSecurityUsage", Justification = "Managed API")]
-        [DllImport(DNSAPI, EntryPoint = "DnsRecordListFree", CallingConvention = CallingConvention.Winapi, CharSet = CharSet.Unicode)]
+        [DllImport(DNSAPI, EntryPoint = "DnsRecordListFree", CallingConvention = CallingConvention.Winapi, CharSet = CharSet.Unicode, ExactSpelling = true)]
         private static extern void DnsRecordListFree([In] IntPtr ptrRecords, [In] FreeType freeType);
 
         /// <summary>

--- a/Properties/Microsoft.Exchange.WebServices.Data.rd.xml
+++ b/Properties/Microsoft.Exchange.WebServices.Data.rd.xml
@@ -27,7 +27,7 @@
 <Directives xmlns="http://schemas.microsoft.com/netfx/2013/01/metadata">
   <Library Name="Microsoft.Exchange.WebServices.Data">
 
-  	<!-- add directives for your library here -->
+    <Namespace Name="Microsoft.Exchange.WebServices" Dynamic="Required All" />
 
   </Library>
 </Directives>


### PR DESCRIPTION
The DNS API calls are not UWP-compliant, but .NET Native will compile with
them anyway if they are marked with the 'ExactSpelling' attribute
parameter. Do this for now until we find an alternative for DNS calls.
